### PR TITLE
Use spreadsheet column name instead of index

### DIFF
--- a/app/services/bin_bag_retailer_importer.rb
+++ b/app/services/bin_bag_retailer_importer.rb
@@ -1,15 +1,18 @@
 class BinBagRetailerImporter
   def self.import_google_sheet!(sheet)
+    columns = sheet.values[0]
     sheet_rows = sheet.values[1..-1]
 
     sheet_rows.each do |sheet_row|
+      retailer = columns.zip(sheet_row).to_h
+
       BinBagRetailer.create!({
-        name: sheet_row[0],
-        address: sheet_row[1],
-        postcode: sheet_row[2],
-        google_map_url: sheet_row[3],
-        google_map_has_opening_hours: sheet_row[4] == "Y",
-        providers: parse_providers(sheet_row[5..7])
+        name: retailer['Shop Name'],
+        address: retailer['Shop Address'],
+        postcode: retailer['Postcode'],
+        google_map_url: retailer['Google Map Location'],
+        google_map_has_opening_hours: retailer['Google Map Opening Times'] == "Y",
+        providers: parse_providers([retailer['Has Keywaste'], retailer['Has Greyhound'], retailer['Has Abbey Waste']])
       })
     end
   end


### PR DESCRIPTION
After renaming provider columns to have unique name (revision
"after-renaming-provider-columns" of the retailers spreadsheet), we can
now access sheet data by column name instead of index. This allows us to
add columns to the spreadsheet without worrying about the order (and
thus the index) of the
columns.